### PR TITLE
Patching Mistake in barycenter_order

### DIFF
--- a/src/barycenter_order.js
+++ b/src/barycenter_order.js
@@ -73,7 +73,7 @@ export function barycenter(graph, comp, max_iter) {
 
   let v;
   const inv_neighbor = (e) =>
-    inv_layer[e.source == v ? e.target : e.source.index];
+    inv_layer[e.source == v ? e.target.index : e.source.index];
 
   const barycenter_sort = (a, b) => {
     let d = med[a] - med[b];


### PR DESCRIPTION
A small mistake was causing the barycenter_order function to not work properly. 
It would always return the initial order. This should fix it, its effects are noticable in the examples.