### PR TITLE
use non-minified reorder.js in saclay demo

### DIFF
--- a/examples/saclay/index.html
+++ b/examples/saclay/index.html
@@ -37,7 +37,7 @@ rect.highlight {
 
 </style>
 <script src="/d3.v3.js"></script>
-<script src="/reorder.min.js"></script>
+<script src="/reorder.js"></script>
 <script src="/matrix.js"></script>
 
 <header>


### PR DESCRIPTION
The other demos use reorder.js, rather than reorder.min.js, which means that they work as soon as the user has run `npm install` and `npm run dev`.

In contrast, the saclay demo fails to load reorder.js with a 404 error until `npm run build` has been run. This is potentially confusing to someone who has checked out the repository for the first time.