### PR TITLE
update readme "npm run build" -> "npm install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ following from the root directory of this repository to install the development
 dependencies:
 
 ```
-npm run install
+npm install
 ```
 
 ## Testing


### PR DESCRIPTION
Running `npm run build` doesn't install the development dependencies - instead it fails with an error saying they are not installed:

![npm-build](https://user-images.githubusercontent.com/338833/117645212-3fd94300-b182-11eb-80a2-b79352dfac7c.png)
